### PR TITLE
Add new conv feature layer supporting arbitrary parameters

### DIFF
--- a/src/distdl/nn/conv_feature.py
+++ b/src/distdl/nn/conv_feature.py
@@ -1,13 +1,12 @@
 import numpy as np
 import torch
+import torch.nn.functional as F
 
 from distdl.nn.broadcast import Broadcast
 from distdl.nn.halo_exchange import HaloExchange
 from distdl.nn.mixins.conv_mixin import ConvMixin
 from distdl.nn.mixins.halo_mixin import HaloMixin
 from distdl.nn.module import Module
-from distdl.nn.padnd import PadNd
-from distdl.nn.unpadnd import UnpadNd
 from distdl.utilities.slicing import assemble_slices
 from distdl.utilities.torch import TensorStructure
 from distdl.utilities.torch import zero_volume_tensor
@@ -45,13 +44,53 @@ class DistributedFeatureConvBase(Module, HaloMixin, ConvMixin):
     ----------
     P_x :
         Partition of input tensor.
-
+    in_channels :
+        (int)
+        Number of channels in the input image
+    out_channels :
+        (int)
+        Number of channels produced by the convolution
+    kernel_size :
+        (int or tuple)
+        Size of the convolving kernel
+    stride :
+        (int or tuple, optional)
+        Stride of the convolution. Default: 1
+    padding :
+        (int or tuple, optional)
+        Zero-padding added to both sides of the input. Default: 0
+    padding_mode :
+        (string, optional)
+        'zeros', 'reflect', 'replicate' or 'circular'. Default: 'zeros'
+    dilation :
+        (int or tuple, optional)
+        Spacing between kernel elements. Default: 1
+    groups :
+        (int, optional)
+        Number of blocked connections from input channels to output channels. Default: 1
+    bias :
+        (bool, optional)
+        If True, adds a learnable bias to the output. Default: True
+    buffer_manager :
+        (BufferManager, optional)
+        DistDL BufferManager. Default: None
     """
 
     # Convolution class for base unit of work.
     TorchConvType = None
 
-    def __init__(self, P_x, buffer_manager=None, *args, **kwargs):
+    def __init__(self,
+                 P_x,
+                 in_channels,
+                 out_channels,
+                 kernel_size,
+                 stride=1,
+                 padding=0,
+                 padding_mode='zeros',
+                 dilation=1,
+                 groups=1,
+                 bias=True,
+                 buffer_manager=None):
 
         super(DistributedFeatureConvBase, self).__init__()
 
@@ -70,12 +109,44 @@ class DistributedFeatureConvBase(Module, HaloMixin, ConvMixin):
 
         # Do this before checking serial so that the layer works properly
         # in the serial case
-        self.conv_layer = self.TorchConvType(*args, **kwargs)
+        self.conv_layer = self.TorchConvType(in_channels=in_channels,
+                                             out_channels=out_channels,
+                                             kernel_size=kernel_size,
+                                             stride=stride,
+                                             padding=0,
+                                             padding_mode='zeros',
+                                             dilation=dilation,
+                                             groups=groups,
+                                             bias=bias)
 
         self.serial = False
         if self.P_x.size == 1:
             self.serial = True
             return
+
+        dims = len(self.P_x.shape)
+
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.kernel_size = kernel_size
+        self.stride = stride
+        self.padding = padding
+        self.padding_mode = padding_mode
+        self.dilation = dilation
+        self.groups = groups
+        self.bias = bias
+
+        # We will be using global padding to compute local padding,
+        # so expand it to a numpy array
+        global_padding = np.atleast_1d(padding)
+        global_padding = np.pad(global_padding,
+                                pad_width=(dims-len(global_padding), 0),
+                                mode='constant',
+                                constant_values=0)
+        self.global_padding = global_padding
+
+        pad_left_right = self.global_padding.reshape((dims, 1)) + np.zeros((dims, 2), dtype=np.int)
+        self.local_padding = self._compute_local_padding(pad_left_right)
 
         # Weights and biases partition
         P_wb = self.P_x.create_partition_inclusive([0])
@@ -121,12 +192,6 @@ class DistributedFeatureConvBase(Module, HaloMixin, ConvMixin):
             self.b_broadcast = Broadcast(self.P_wb_cart, self.P_x,
                                          preserve_batch=False)
 
-        # We need the halo shape, and other info, to fully populate the pad,
-        # halo exchange, and unpad layers.  For pad and unpad, we defer their
-        # construction to the pre-forward hook.
-        self.pad_layer = None
-        self.unpad_layer = None
-
         # We need to be able to remove some data from the input to the conv
         # layer.
         self.needed_slices = None
@@ -164,27 +229,40 @@ class DistributedFeatureConvBase(Module, HaloMixin, ConvMixin):
         if self.serial:
             return
 
-        # To compute the halo regions, we need the global tensor shape.  This
-        # is not available until when the input is provided.
+        # Compute global and local shapes with padding
         x_global_structure = \
             self._distdl_backend.assemble_global_tensor_structure(input[0], self.P_x)
+        x_local_structure = TensorStructure(input[0])
+        x_global_shape = x_global_structure.shape
+        x_local_shape = x_local_structure.shape
+        x_global_shape_after_pad = x_global_shape + 2*self.global_padding
+        x_local_shape_after_pad = x_local_shape + np.sum(self.local_padding, axis=1, keepdims=False)
+        x_local_structure_after_pad = TensorStructure(input[0])
+        x_local_structure_after_pad.shape = x_local_shape_after_pad
+
+        # We need to compute the halos with respect to the explicit padding.
+        # So, we assume the padding is already added, then compute the halo regions.
+        compute_subtensor_shapes_unbalanced = \
+            self._distdl_backend.tensor_decomposition.compute_subtensor_shapes_unbalanced
+        subtensor_shapes = \
+            compute_subtensor_shapes_unbalanced(x_local_structure_after_pad, self.P_x)
 
         # Using that information, we can get there rest of the halo information
-        exchange_info = self._compute_exchange_info(x_global_structure.shape,
-                                                    self.conv_layer.kernel_size,
-                                                    self.conv_layer.stride,
-                                                    self.conv_layer.padding,
-                                                    self.conv_layer.dilation,
+        exchange_info = self._compute_exchange_info(x_global_shape_after_pad,
+                                                    self.kernel_size,
+                                                    self.stride,
+                                                    0,
+                                                    self.dilation,
                                                     self.P_x.active,
                                                     self.P_x.shape,
-                                                    self.P_x.index)
+                                                    self.P_x.index,
+                                                    subtensor_shapes=subtensor_shapes)
         halo_shape = exchange_info[0]
         recv_buffer_shape = exchange_info[1]
         send_buffer_shape = exchange_info[2]
         needed_ranges = exchange_info[3]
 
-        # Now we have enough information to instantiate the padding shim
-        self.pad_layer = PadNd(halo_shape, value=0)
+        self.halo_shape = halo_shape
 
         # We can also set up part of the halo layer.
         self.halo_layer = HaloExchange(self.P_x,
@@ -197,17 +275,6 @@ class DistributedFeatureConvBase(Module, HaloMixin, ConvMixin):
         # be "negative" halos.
         self.needed_slices = assemble_slices(needed_ranges[:, 0],
                                              needed_ranges[:, 1])
-
-        # Unpad shape are conv layer's padding in the dimensions where we have
-        # a halo, otherwise 0.  There is no halo in the batch and channel
-        # dimensions.
-        conv_padding = np.concatenate(([0, 0], self.conv_layer.padding))
-        unpad_shape = []
-        for pad, halo in zip(conv_padding, halo_shape):
-            unpad_shape.append(np.where(halo > 0, pad, 0))
-        unpad_shape = np.asarray(unpad_shape)
-
-        self.unpad_layer = UnpadNd(unpad_shape, value=0)
 
     def _distdl_module_teardown(self, input):
         r"""Distributed (channel) convolution module teardown function.
@@ -224,8 +291,6 @@ class DistributedFeatureConvBase(Module, HaloMixin, ConvMixin):
         """
 
         # Reset all sub_layers
-        self.pad_layer = None
-        self.unpad_layer = None
         self.needed_slices = None
         self.halo_layer = None
 
@@ -247,6 +312,26 @@ class DistributedFeatureConvBase(Module, HaloMixin, ConvMixin):
         new_tensor_structure = TensorStructure(input[0])
 
         return self._input_tensor_structure != new_tensor_structure
+
+    def _to_torch_padding(self, pad):
+        r"""
+        Accepts a NumPy ndarray describing the padding, and produces the torch F.pad format:
+            [[a_0, b_0], ..., [a_n, b_n]]  ->  (a_n, b_n, ..., a_0, b_0)
+
+        """
+        return tuple(np.array(list(reversed(pad)), dtype=int).flatten())
+
+    def _compute_local_padding(self, padding):
+        r"""
+        Computes the amount of explicit padding required on the current rank,
+        given the global padding.
+
+        """
+        should_pad_left = [k == 0 for k in self.P_x.index]
+        should_pad_right = [k == d-1 for k, d in zip(self.P_x.index, self.P_x.shape)]
+        should_pad = np.stack((should_pad_left, should_pad_right), axis=1)
+        local_padding = np.where(should_pad, padding, 0)
+        return local_padding
 
     def forward(self, input):
         r"""Forward function interface.
@@ -271,11 +356,20 @@ class DistributedFeatureConvBase(Module, HaloMixin, ConvMixin):
             b = self.b_broadcast(self.bias)
             self.conv_layer.bias = b
 
-        input_padded = self.pad_layer(input)
+        # Compute the total padding and convert to PyTorch format
+        total_padding = self.local_padding + self.halo_shape
+        torch_padding = self._to_torch_padding(total_padding)
+
+        if total_padding.sum() == 0:
+            input_padded = input
+        else:
+            pad_mode = 'constant' if self.padding_mode == 'zeros' else self.padding_mode
+            input_padded = F.pad(input, pad=torch_padding, mode=pad_mode, value=0)
+
         input_exchanged = self.halo_layer(input_padded)
         input_needed = input_exchanged[self.needed_slices]
         conv_output = self.conv_layer(input_needed)
-        return self.unpad_layer(conv_output)
+        return conv_output
 
 
 class DistributedFeatureConv1d(DistributedFeatureConvBase):

--- a/src/distdl/nn/mixins/conv_mixin.py
+++ b/src/distdl/nn/mixins/conv_mixin.py
@@ -11,10 +11,6 @@ class ConvMixin:
                                  dilation):
         r"""Compute left index required to apply a kernel at a given index.
 
-        .. warning::
-           This does not currently take stride and dilation into account.
-           Therefore, the padding values may not be correct in these cases.
-
         Parameters
         ----------
         idx :
@@ -35,15 +31,7 @@ class ConvMixin:
 
         """
 
-        # incorrect, does not take stride and dilation into account
-        # padding might also not be correct in these cases...
-        kernel_offsets = (kernel_size - 1) / 2
-
-        # for even sized kernels, always shortchange the left side
-        kernel_offsets[kernel_size % 2 == 0] -= 1
-
-        bases = idx + kernel_offsets - padding
-        return bases - kernel_offsets
+        return stride * idx - padding
 
     def _compute_max_input_range(self,
                                  idx,
@@ -52,10 +40,6 @@ class ConvMixin:
                                  padding,
                                  dilation):
         r"""Compute right index required to apply a kernel at a given index.
-
-        .. warning::
-           This does not currently take stride and dilation into account.
-           Therefore, the padding values may not be correct in these cases.
 
         Parameters
         ----------
@@ -77,9 +61,4 @@ class ConvMixin:
 
         """
 
-        # incorrect, does not take stride and dilation into account
-        # padding might also not be correct in these cases...
-        kernel_offsets = (kernel_size - 1) / 2
-
-        bases = idx + kernel_offsets - padding
-        return bases + kernel_offsets
+        return stride * idx + dilation * (kernel_size - 1) - padding

--- a/tests/test_conv_feature.py
+++ b/tests/test_conv_feature.py
@@ -1,0 +1,334 @@
+import numpy as np
+import pytest
+
+# These tests aim to compare DistributedConvNd functionality to PyTorch's ConvNd.
+
+params = []
+
+# No stride, and ideal padding for kernel size
+params.append(
+    pytest.param(
+        np.arange(0, 4), [1, 1, 2, 2],  # P_x_ranks, P_x_shape
+        2,  # input_dimensions
+        [1, 5, 10, 10],  # x_global_shape
+        [3, 3],  # kernel_size
+        [1, 1],  # padding
+        [1, 1],  # stride
+        [1, 1],  # dilation
+        False,  # bias
+        4,  # passed to comm_split_fixture, required MPI ranks
+        id="no-stride-ideal-padding",
+        marks=[pytest.mark.mpi(min_size=4)]
+        )
+    )
+
+# Basic example with stride = 2 and ideal padding
+params.append(
+   pytest.param(
+       np.arange(0, 4), [1, 1, 2, 2],  # P_x_ranks, P_x_shape
+       2,  # input_dimensions
+       [1, 5, 10, 10],  # x_global_shape
+       [5, 5],  # kernel_size
+       [2, 2],  # padding
+       [2, 2],  # stride
+       [1, 1],  # dilation
+       False,  # bias
+       4,  # passed to comm_split_fixture, required MPI ranks
+       id="stride-2-ideal-padding",
+       marks=[pytest.mark.mpi(min_size=4)]
+       )
+   )
+
+# Odd local x shape with stride
+params.append(
+    pytest.param(
+        np.arange(0, 4), [1, 1, 2, 2],  # P_x_ranks, P_x_shape
+        2,  # input_dimensions
+        [1, 5, 5, 5],  # x_global_shape
+        [3, 3],  # kernel_size
+        [1, 1],  # padding
+        [2, 2],  # stride
+        [1, 1],  # dilation
+        False,  # bias
+        4,  # passed to comm_split_fixture, required MPI ranks
+        id="odd-local-shape-with-stride",
+        marks=[pytest.mark.mpi(min_size=4)]
+        )
+    )
+
+# First kernel does not begin on local x left edge
+params.append(
+    pytest.param(
+        np.arange(0, 4), [1, 1, 2, 2],  # P_x_ranks, P_x_shape
+        2,  # input_dimensions
+        [1, 5, 6, 10],  # x_global_shape
+        [5, 5],  # kernel_size
+        [2, 2],  # padding
+        [4, 4],  # stride
+        [1, 1],  # dilation
+        False,  # bias
+        4,  # passed to comm_split_fixture, required MPI ranks
+        id="kernel-needs-offset",
+        marks=[pytest.mark.mpi(min_size=4)]
+        )
+    )
+
+# Non-ideal padding
+params.append(
+    pytest.param(
+        np.arange(0, 4), [1, 1, 2, 2],  # P_x_ranks, P_x_shape
+        2,  # input_dimensions
+        [1, 5, 10, 8],  # x_global_shape
+        [5, 5],  # kernel_size
+        [1, 1],  # padding
+        [1, 1],  # stride
+        [1, 1],  # dilation
+        False,  # bias
+        4,  # passed to comm_split_fixture, required MPI ranks
+        id="non-ideal-padding",
+        marks=[pytest.mark.mpi(min_size=4)]
+        )
+    )
+
+# Even kernel size with bias
+params.append(
+    pytest.param(
+        np.arange(0, 4), [1, 1, 2, 2],  # P_x_ranks, P_x_shape
+        2,  # input_dimensions
+        [1, 5, 8, 8],  # x_global_shape
+        [4, 4],  # kernel_size
+        [1, 1],  # padding
+        [1, 1],  # stride
+        [1, 1],  # dilation
+        True,  # bias
+        4,  # passed to comm_split_fixture, required MPI ranks
+        id="even-kernel-size-with-bias",
+        marks=[pytest.mark.mpi(min_size=4)]
+        )
+    )
+
+# 3D input
+params.append(
+    pytest.param(
+        np.arange(0, 4), [1, 1, 2, 1, 2],  # P_x_ranks, P_x_shape
+        3,  # input_dimensions
+        [1, 3, 5, 5, 6],  # x_global_shape
+        [5, 5, 5],  # kernel_size
+        [2, 2, 2],  # padding
+        [2, 2, 1],  # stride
+        [1, 1, 1],  # dilation
+        False,  # bias
+        4,  # passed to comm_split_fixture, required MPI ranks
+        id="3d-input",
+        marks=[pytest.mark.mpi(min_size=4)]
+        )
+    )
+
+# 1D input
+params.append(
+   pytest.param(
+       np.arange(0, 4), [1, 1, 4],  # P_x_ranks, P_x_shape
+       1,  # input_dimensions
+       [1, 3, 15],  # x_global_shape
+       3,  # kernel_size
+       1,  # padding
+       1,  # stride
+       1,  # dilation
+       False,  # bias
+       4,  # passed to comm_split_fixture, required MPI ranks
+       id="1d-input",
+       marks=[pytest.mark.mpi(min_size=4)]
+       )
+   )
+
+# Dilation = 2
+params.append(
+   pytest.param(
+       np.arange(0, 4), [1, 1, 2, 2],  # P_x_ranks, P_x_shape
+       2,  # input_dimensions
+       [1, 3, 10, 10],  # x_global_shape
+       [5, 5],  # kernel_size
+       [1, 1],  # padding
+       [1, 1],  # stride
+       [2, 2],  # dilation
+       False,  # bias
+       4,  # passed to comm_split_fixture, required MPI ranks
+       id="dilation-2",
+       marks=[pytest.mark.mpi(min_size=4)]
+       )
+   )
+
+# Lots of partitions
+params.append(
+   pytest.param(
+       np.arange(0, 16), [1, 1, 4, 4],  # P_x_ranks, P_x_shape
+       2,  # input_dimensions
+       [1, 3, 10, 10],  # x_global_shape
+       [5, 5],  # kernel_size
+       [2, 2],  # padding
+       [2, 2],  # stride
+       [1, 1],  # dilation
+       False,  # bias
+       16,  # passed to comm_split_fixture, required MPI ranks
+       id="many-partitions-small-input",
+       marks=[pytest.mark.mpi(min_size=16)]
+       )
+   )
+
+# With bias
+params.append(
+   pytest.param(
+       np.arange(0, 4), [1, 1, 2, 2],  # P_x_ranks, P_x_shape
+       2,  # input_dimensions
+       [1, 5, 10, 10],  # x_global_shape
+       [3, 3],  # kernel_size
+       [1, 1],  # padding
+       [1, 1],  # stride
+       [1, 1],  # dilation
+       True,  # bias
+       4,  # passed to comm_split_fixture, required MPI ranks
+       id="with-bias",
+       marks=[pytest.mark.mpi(min_size=4)]
+       )
+   )
+
+# 3D input with bias, stride, dilation, non-ideal lop-sided kernel, and large input
+params.append(
+    pytest.param(
+        np.arange(0, 18), [1, 1, 3, 3, 2],  # P_x_ranks, P_x_shape
+        3,  # input_dimensions
+        [1, 5, 50, 50, 50],  # x_global_shape
+        [5, 4, 3],  # kernel_size
+        [1, 1, 2],  # padding
+        [3, 1, 2],  # stride
+        [3, 3, 1],  # dilation
+        True,  # bias
+        18,  # passed to comm_split_fixture, required MPI ranks
+        id="hard-test",
+        marks=[pytest.mark.mpi(min_size=18)]
+        )
+    )
+
+
+@pytest.mark.parametrize("P_x_ranks, P_x_shape,"
+                         "input_dimensions,"
+                         "x_global_shape,"
+                         "kernel_size,"
+                         "padding,"
+                         "stride,"
+                         "dilation,"
+                         "bias,"
+                         "comm_split_fixture",
+                         params,
+                         indirect=["comm_split_fixture"])
+def test_conv_versus_pytorch(barrier_fence_fixture,
+                             comm_split_fixture,
+                             P_x_ranks, P_x_shape,
+                             input_dimensions,
+                             x_global_shape,
+                             kernel_size,
+                             padding,
+                             stride,
+                             dilation,
+                             bias):
+
+    import numpy as np
+    import torch
+    from torch.nn import Conv1d
+    from torch.nn import Conv2d
+    from torch.nn import Conv3d
+
+    from distdl.backends.mpi.partition import MPIPartition
+    from distdl.nn.conv_feature import DistributedFeatureConv1d
+    from distdl.nn.conv_feature import DistributedFeatureConv2d
+    from distdl.nn.conv_feature import DistributedFeatureConv3d
+    from distdl.nn.transpose import DistributedTranspose
+    from distdl.utilities.torch import zero_volume_tensor
+
+    # Isolate the minimum needed ranks
+    base_comm, active = comm_split_fixture
+    if not active:
+        return
+    P_world = MPIPartition(base_comm)
+    P_world._comm.Barrier()
+
+    # Create the partitions
+    P_root_base = P_world.create_partition_inclusive(np.arange(1))
+    P_x_base = P_world.create_partition_inclusive(P_x_ranks)
+    P_root = P_root_base.create_cartesian_topology_partition([1]*len(P_x_shape))
+    P_x = P_x_base.create_cartesian_topology_partition(P_x_shape)
+
+    # Create the layers
+    if input_dimensions == 1:
+        dist_layer_type = DistributedFeatureConv1d
+        seq_layer_type = Conv1d
+    elif input_dimensions == 2:
+        dist_layer_type = DistributedFeatureConv2d
+        seq_layer_type = Conv2d
+    elif input_dimensions == 3:
+        dist_layer_type = DistributedFeatureConv3d
+        seq_layer_type = Conv3d
+    scatter = DistributedTranspose(P_root, P_x)
+    dist_layer = dist_layer_type(P_x,
+                                 in_channels=x_global_shape[1],
+                                 out_channels=10,
+                                 kernel_size=kernel_size,
+                                 padding=padding,
+                                 stride=stride,
+                                 dilation=dilation,
+                                 bias=bias)
+    gather = DistributedTranspose(P_x, P_root)
+    if P_root.active:
+        seq_layer = seq_layer_type(in_channels=x_global_shape[1],
+                                   out_channels=10,
+                                   kernel_size=kernel_size,
+                                   padding=padding,
+                                   stride=stride,
+                                   dilation=dilation,
+                                   bias=bias)
+        # set the weights of both layers to be the same
+        weight = torch.rand_like(seq_layer.weight)
+        seq_layer.weight.data = weight
+        dist_layer.weight.data = weight
+        if bias:
+            bias_weight = torch.rand_like(seq_layer.bias)
+            seq_layer.bias.data = bias_weight
+            dist_layer.bias.data = bias_weight
+
+    # Create the input
+    if P_root.active:
+        x = np.random.randn(*x_global_shape)
+        dist_x = torch.from_numpy(x.copy()).to(torch.float32)
+        seq_x = torch.from_numpy(x.copy()).to(torch.float32)
+        dist_x.requires_grad = True
+        seq_x.requires_grad = True
+
+        if dist_x.dtype == torch.float64:
+            atol = 1e-8
+        elif dist_x.dtype == torch.float32:
+            atol = 1e-5
+        else:
+            # torch default
+            atol = 1e-8
+    else:
+        dist_x = zero_volume_tensor(requires_grad=True)
+
+    # Check the forward pass
+    dist_y = gather(dist_layer(scatter(dist_x)))
+    if P_root.active:
+        seq_y = seq_layer(seq_x)
+        assert dist_y.shape == seq_y.shape
+        assert torch.allclose(dist_y, seq_y, atol=atol)
+
+    # Check the backward pass
+    dist_y.sum().backward()
+    dist_dx = dist_x.grad
+    if P_root.active:
+        seq_y.sum().backward()
+        seq_dx = seq_x.grad
+        assert dist_dx.shape == seq_dx.shape
+        assert np.allclose(dist_dx, seq_dx, atol=atol)
+
+    P_world.deactivate()
+    P_x_base.deactivate()
+    P_x.deactivate()


### PR DESCRIPTION
This adds a new Conv Feature layer that supports arbitrary/unbalanced input sizes, kernels, padding, stride, and dilation. A new set of tests are added, to demonstrate that the layer functions equivalently to the PyTorch ConvNd layers for the tested set of cases. A warning is added in the documentation to inform users to use the new conv layer when using non-default stride, dilation, or input size. Eventually, this layer should be refactored into the existing conv feature layer.

Some additional logic was added to HaloMixin to handle the unbalanced input case. The logic of the functions in ConvMixin is simplified slightly, and has been corrected for stride and dilation. The warning in the documentation of ConvMixin is removed.