### PR TITLE
bug(#200) Corrected shape preservation in subpartition.

### DIFF
--- a/src/distdl/backends/mpi/partition.py
+++ b/src/distdl/backends/mpi/partition.py
@@ -970,7 +970,7 @@ class MPICartesianPartition(MPIPartition):
 
             return MPICartesianPartition(comm, group,
                                          self._root,
-                                         self.shape[remain_shape == True]) # noqa E712
+                                         self.shape[remain_shape])
 
         else:
             comm = MPI.COMM_NULL


### PR DESCRIPTION
Before this, the shape would be [] but now the shape is correct based
on the remaining dimensions.