### PR TITLE
bug(#208) fix conv feature serial case

### DIFF
--- a/tests/test_conv_feature.py
+++ b/tests/test_conv_feature.py
@@ -226,6 +226,23 @@ params.append(
         )
     )
 
+# serial case
+params.append(
+    pytest.param(
+        np.arange(0, 1), [1, 1, 1, 1],  # P_x_ranks, P_x_shape
+        2,  # input_dimensions
+        [1, 3, 16, 16],  # x_global_shape
+        3,  # kernel_size
+        1,  # padding
+        1,  # stride
+        1,  # dilation
+        False,  # bias
+        1,  # passed to comm_split_fixture, required MPI ranks
+        id="serial-test",
+        marks=[pytest.mark.mpi(min_size=1)]
+        )
+    )
+
 
 @pytest.mark.parametrize("P_x_ranks, P_x_shape,"
                          "input_dimensions,"


### PR DESCRIPTION
This fixes a bug with the distributed conv feature layer in the serial case (1 worker). Since we changed how we handle pad, we must change how we initialize the inner conv layer in the serial case. Specifically, this initializes the inner conv layer to use the given padding in the serial case, and changes nothing for the distributed case.