### PR TITLE
Add GPU support to MPI backend

### DIFF
--- a/src/distdl/functional/zero_volume_corrector.py
+++ b/src/distdl/functional/zero_volume_corrector.py
@@ -54,7 +54,7 @@ class ZeroVolumeCorrectorFunction(torch.autograd.Function):
         ctx.zero_volume = np.prod(input.shape) == 0
 
         if ctx.zero_volume:
-            return torch.tensor(0.0, requires_grad=True).float()
+            return torch.tensor(0.0, requires_grad=True, device=input.device).float()
         else:
             return input.clone()
 
@@ -82,6 +82,6 @@ class ZeroVolumeCorrectorFunction(torch.autograd.Function):
         sh = ctx.sh
 
         if ctx.zero_volume:
-            return zero_volume_tensor(sh[0])
+            return zero_volume_tensor(sh[0], device=grad_output.device)
         else:
             return grad_output.clone()

--- a/src/distdl/nn/batchnorm.py
+++ b/src/distdl/nn/batchnorm.py
@@ -82,8 +82,8 @@ class DistributedBatchNorm(Module):
         P_sum_base.deactivate()
 
         if self.track_running_stats:
-            self.running_mean = torch.zeros(internal_data_shape)
-            self.running_var = torch.ones(internal_data_shape)
+            self.register_buffer('running_mean', torch.zeros(internal_data_shape))
+            self.register_buffer('running_var', torch.ones(internal_data_shape))
         else:
             self.running_mean = None
             self.running_var = None
@@ -97,8 +97,8 @@ class DistributedBatchNorm(Module):
                 self.gamma = torch.nn.Parameter(torch.ones(internal_data_shape))
                 self.beta = torch.nn.Parameter(torch.zeros(internal_data_shape))
             else:
-                self.gamma = zero_volume_tensor(requires_grad=True)
-                self.beta = zero_volume_tensor(requires_grad=True)
+                self.register_buffer('gamma', zero_volume_tensor(requires_grad=True))
+                self.register_buffer('beta', zero_volume_tensor(requires_grad=True))
 
     def _distdl_module_setup(self, input):
         r"""Distributed batch norm module setup function.
@@ -155,7 +155,7 @@ class DistributedBatchNorm(Module):
 
         """
 
-        x = (input - mean)**2
+        x = (input - mean) ** 2
         return self._compute_mean(x, feature_volume)
 
     def _update_running_stats(self, mean, var):

--- a/src/distdl/nn/conv_feature.py
+++ b/src/distdl/nn/conv_feature.py
@@ -119,7 +119,7 @@ class DistributedFeatureConvBase(Module, HaloMixin, ConvMixin):
         self.padding_mode = padding_mode
         self.dilation = self._expand_parameter(dilation)
         self.groups = groups
-        self.bias = bias
+        self.use_bias = bias
 
         self.serial = self.P_x.size == 1
 
@@ -132,7 +132,7 @@ class DistributedFeatureConvBase(Module, HaloMixin, ConvMixin):
                                                  padding_mode=self.padding_mode,
                                                  dilation=self.dilation,
                                                  groups=self.groups,
-                                                 bias=self.bias)
+                                                 bias=self.use_bias)
             self.weight = self.conv_layer.weight
             self.bias = self.conv_layer.bias
         else:
@@ -175,10 +175,10 @@ class DistributedFeatureConvBase(Module, HaloMixin, ConvMixin):
             if self.conv_layer.bias is not None:
                 self.bias = torch.nn.Parameter(self.conv_layer.bias.detach())
         else:
-            self.weight = zero_volume_tensor()
+            self.register_buffer('weight', zero_volume_tensor())
 
             if self.conv_layer.bias is not None:
-                self.bias = zero_volume_tensor()
+                self.register_buffer('bias', zero_volume_tensor())
 
         self.weight.requires_grad = self.conv_layer.weight.requires_grad
 

--- a/src/distdl/nn/conv_general.py
+++ b/src/distdl/nn/conv_general.py
@@ -241,7 +241,7 @@ class DistributedGeneralConvBase(Module, HaloMixin, ConvMixin):
             if self.stores_weight:
                 self._weight = torch.nn.Parameter(self.conv_layer.weight.detach())
             else:
-                self._weight = zero_volume_tensor()
+                self.register_buffer('_weight', zero_volume_tensor())
             # This always exists so we can copy the property
             self._weight.requires_grad = self.conv_layer.weight.requires_grad
 
@@ -257,7 +257,7 @@ class DistributedGeneralConvBase(Module, HaloMixin, ConvMixin):
             if self.stores_bias:
                 self._bias = torch.nn.Parameter(self.conv_layer.bias.detach())
             else:
-                self._bias = zero_volume_tensor()
+                self.register_buffer('_bias', zero_volume_tensor())
             # This does not always exist, but when it does we can copy the
             # property.
             if self.receives_bias:

--- a/src/distdl/nn/unpadnd.py
+++ b/src/distdl/nn/unpadnd.py
@@ -1,38 +1,6 @@
 import numpy as np
 import torch
-
-
-class UnpadNdFunction(torch.autograd.Function):
-
-    @staticmethod
-    def forward(ctx, input, pad_width, value):
-
-        ctx.value = value
-        ctx.pad_width = pad_width
-
-        slices = []
-        for (lpad, rpad) in pad_width:
-            start = lpad
-            stop = -rpad if rpad > 0 else None
-            slices.append(slice(start, stop, 1))
-
-        input_numpy = input.detach().numpy()
-
-        result = input_numpy[tuple(slices)]
-
-        return torch.tensor(result, requires_grad=input.requires_grad)
-
-    @staticmethod
-    def backward(ctx, grad_output):
-
-        value = ctx.value
-        pad_width = ctx.pad_width
-
-        grad_output_numpy = grad_output.detach().numpy()
-
-        result = np.pad(grad_output_numpy, pad_width, mode='constant', constant_values=value)
-
-        return torch.tensor(result, requires_grad=grad_output.requires_grad), None, None, None
+import torch.nn.functional as F
 
 
 class UnpadNd(torch.nn.Module):
@@ -43,6 +11,22 @@ class UnpadNd(torch.nn.Module):
 
         self.pad_width = pad_width
         self.value = value
+        self.torch_pad = self._to_torch_padding(pad_width)
+        self.slices = []
+        for (lpad, rpad) in pad_width:
+            start = lpad
+            stop = -rpad if rpad > 0 else None
+            self.slices.append(slice(start, stop, 1))
+
+    def _to_torch_padding(self, pad):
+        r"""
+        Accepts a NumPy ndarray describing the padding, and produces the torch F.pad format:
+            [[a_0, b_0], ..., [a_n, b_n]]  ->  (a_n, b_n, ..., a_0, b_0)
+        """
+        return tuple(np.array(list(reversed(pad)), dtype=int).flatten())
 
     def forward(self, input):
-        return UnpadNdFunction.apply(input, self.pad_width, self.value)
+        return input[tuple(self.slices)]
+
+    def backward(self, grad_output):
+        return F.pad(grad_output, self.torch_pad, mode='constant', value=self.value)

--- a/src/distdl/utilities/torch.py
+++ b/src/distdl/utilities/torch.py
@@ -1,15 +1,15 @@
 import torch
 
 
-def zero_volume_tensor(b=None, dtype=None, requires_grad=False):
+def zero_volume_tensor(b=None, dtype=None, requires_grad=False, device=None):
 
     if dtype is None:
         dtype = torch.get_default_dtype()
 
     if b is None:
-        return torch.empty((0,), dtype=dtype, requires_grad=requires_grad)
+        return torch.empty((0,), dtype=dtype, requires_grad=requires_grad, device=device)
 
-    return torch.empty((b, 0), dtype=dtype, requires_grad=requires_grad)
+    return torch.empty((b, 0), dtype=dtype, requires_grad=requires_grad, device=device)
 
 
 class TensorStructure:

--- a/tests/adjoint_test.py
+++ b/tests/adjoint_test.py
@@ -10,6 +10,11 @@ from mpi4py import MPI
 # under the tight adjoint test
 def check_adjoint_test_tight(P, x1, x2, y1, y2):
 
+    x1 = x1.cpu()
+    x2 = x2.cpu()
+    y1 = y1.cpu()
+    y2 = y2.cpu()
+
     local_results = np.zeros(6, dtype=np.float64)
     global_results = np.zeros(6, dtype=np.float64)
 
@@ -52,6 +57,11 @@ def check_adjoint_test_tight(P, x1, x2, y1, y2):
 
 
 def check_adjoint_test_tight_sequential(x1, x2, y1, y2):
+
+    x1 = x1.cpu()
+    x2 = x2.cpu()
+    y1 = y1.cpu()
+    y2 = y2.cpu()
 
     local_results = np.zeros(6, dtype=np.float64)
     global_results = np.zeros(6, dtype=np.float64)

--- a/tests/test_batchnorm.py
+++ b/tests/test_batchnorm.py
@@ -1,9 +1,13 @@
+import os
+
 import numpy as np
 import pytest
 import torch
 
 import distdl
 from distdl.utilities.torch import zero_volume_tensor
+
+use_cuda = 'USE_CUDA' in os.environ
 
 ERROR_THRESHOLD = 1e-4
 parametrizations_affine = []
@@ -133,6 +137,8 @@ def test_batch_norm_with_training(barrier_fence_fixture,
 
     torch.manual_seed(0)
 
+    device = torch.device('cuda' if use_cuda else 'cpu')
+
     # Isolate the minimum needed ranks
     base_comm, active = comm_split_fixture
     if not active:
@@ -149,13 +155,13 @@ def test_batch_norm_with_training(barrier_fence_fixture,
 
     # Create the input
     if P_world.rank == 0:
-        input_train = torch.rand(input_shape, dtype=torch.float32)
-        input_eval = torch.rand(input_shape, dtype=torch.float32)
-        exp = torch.rand(input_shape, dtype=torch.float32)
+        input_train = torch.rand(input_shape, dtype=torch.float32, device=device)
+        input_eval = torch.rand(input_shape, dtype=torch.float32, device=device)
+        exp = torch.rand(input_shape, dtype=torch.float32, device=device)
     else:
-        input_train = zero_volume_tensor()
-        input_eval = zero_volume_tensor()
-        exp = zero_volume_tensor()
+        input_train = zero_volume_tensor(device=device)
+        input_eval = zero_volume_tensor(device=device)
+        exp = zero_volume_tensor(device=device)
 
     # Create the sequential network
     if len(input_shape) == 2:
@@ -172,6 +178,7 @@ def test_batch_norm_with_training(barrier_fence_fixture,
                            momentum=momentum,
                            affine=affine,
                            track_running_stats=track_running_stats)
+        seq_bn = seq_bn.to(device)
 
     # Train sequential network
     if P_world.rank == 0:
@@ -179,7 +186,7 @@ def test_batch_norm_with_training(barrier_fence_fixture,
         seq_out1 = seq_bn(input_train)
         seq_loss = ((seq_out1 - exp)**2).sum()
         seq_loss.backward()
-        seq_grads = [p.grad for p in seq_bn.parameters()]
+        seq_grads = [p.grad.detach().cpu() for p in seq_bn.parameters()]
         # Do a manual weight update (this is what optimizer does):
         with torch.no_grad():
             for p in seq_bn.parameters():
@@ -189,16 +196,20 @@ def test_batch_norm_with_training(barrier_fence_fixture,
     if P_world.rank == 0:
         seq_bn.eval()
         seq_out2 = seq_bn(input_eval)
+        seq_out2 = seq_out2.detach().cpu()
 
     # Create distributed network
     tr1 = distdl.nn.DistributedTranspose(P_in_out, P_x)
+    tr1 = tr1.to(device)
     dist_bn = distdl.nn.DistributedBatchNorm(P_x,
                                              num_features=num_features,
                                              eps=eps,
                                              momentum=momentum,
                                              affine=affine,
                                              track_running_stats=track_running_stats)
+    dist_bn = dist_bn.to(device)
     tr2 = distdl.nn.DistributedTranspose(P_x, P_in_out)
+    tr2 = tr2.to(device)
 
     # Only rank 0 should have trainable parameters:
     if P_world.rank in affine_workers:
@@ -220,9 +231,9 @@ def test_batch_norm_with_training(barrier_fence_fixture,
     if P_world.rank in affine_workers:
         for p in dist_bn.parameters():
             if affine_workers == [0]:
-                parts = [p.grad]
+                parts = [p.grad.detach().cpu()]
             else:
-                parts = P_affine._comm.gather(p.grad, root=0)
+                parts = P_affine._comm.gather(p.grad.detach().cpu(), root=0)
             if P_world.rank == 0:
                 grad = torch.cat(parts, 1)
                 reshaped = grad.reshape((num_features,))
@@ -235,6 +246,7 @@ def test_batch_norm_with_training(barrier_fence_fixture,
     # Evaluate distributed network
     dist_bn.eval()
     dist_out2 = tr2(dist_bn(tr1(input_eval)))
+    dist_out2 = dist_out2.detach().cpu()
 
     # Compare the distributed and sequential networks
     if P_world.rank == 0:
@@ -289,6 +301,8 @@ def test_batch_norm_no_training(barrier_fence_fixture,
 
     from distdl.backends.mpi.partition import MPIPartition
 
+    device = torch.device('cuda' if use_cuda else 'cpu')
+
     torch.manual_seed(0)
 
     # Isolate the minimum needed ranks
@@ -306,9 +320,9 @@ def test_batch_norm_no_training(barrier_fence_fixture,
 
     # Create the input
     if P_world.rank == 0:
-        input_eval = torch.rand(input_shape, dtype=torch.float32)
+        input_eval = torch.rand(input_shape, dtype=torch.float32, device=device)
     else:
-        input_eval = zero_volume_tensor()
+        input_eval = zero_volume_tensor(device=device)
 
     # Create the sequential network
     if P_world.rank == 0:
@@ -317,11 +331,15 @@ def test_batch_norm_no_training(barrier_fence_fixture,
                                                            momentum=momentum,
                                                            affine=affine,
                                                            track_running_stats=track_running_stats))
+        seq_net = seq_net.to(device)
+    else:
+        seq_net = None
 
     # Evaluate sequential network
     if P_world.rank == 0:
         seq_net.eval()
         seq_out = seq_net(input_eval)
+        seq_out = seq_out.detach().cpu()
 
     # Create distributed network
     dist_net = torch.nn.Sequential(distdl.nn.DistributedTranspose(P_in_out, P_x),
@@ -332,10 +350,12 @@ def test_batch_norm_no_training(barrier_fence_fixture,
                                                                   affine=affine,
                                                                   track_running_stats=track_running_stats),
                                    distdl.nn.DistributedTranspose(P_x, P_in_out))
+    dist_net = dist_net.to(device)
 
     # Evaluate distributed network
     dist_net.eval()
     dist_out = dist_net(input_eval)
+    dist_out = dist_out.detach().cpu()
 
     # Compare the distributed and sequential networks
     if P_world.rank == 0:

--- a/tests/test_halo_exchange.py
+++ b/tests/test_halo_exchange.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 import pytest
 import torch
@@ -6,6 +8,8 @@ from adjoint_test import check_adjoint_test_tight
 from distdl.nn.mixins.conv_mixin import ConvMixin
 from distdl.nn.mixins.halo_mixin import HaloMixin
 from distdl.nn.mixins.pooling_mixin import PoolingMixin
+
+use_cuda = 'USE_CUDA' in os.environ
 
 
 class MockConvLayer(HaloMixin, ConvMixin):
@@ -112,6 +116,8 @@ def test_halo_exchange_adjoint(barrier_fence_fixture,
     from distdl.utilities.slicing import compute_subshape
     from distdl.utilities.torch import zero_volume_tensor
 
+    device = torch.device('cuda' if use_cuda else 'cpu')
+
     # Isolate the minimum needed ranks
     base_comm, active = comm_split_fixture
     if not active:
@@ -144,20 +150,22 @@ def test_halo_exchange_adjoint(barrier_fence_fixture,
         send_buffer_shape = exchange_info[2]
 
     pad_layer = PadNd(halo_shape, value=0)
+    pad_layer = pad_layer.to(device)
     halo_layer = HaloExchange(P_x, halo_shape, recv_buffer_shape, send_buffer_shape)
+    halo_layer = halo_layer.to(device)
 
-    x = zero_volume_tensor(x_global_shape[0])
+    x = zero_volume_tensor(x_global_shape[0], device=device)
     if P_x.active:
         x_local_shape = compute_subshape(P_x.shape,
                                          P_x.index,
                                          x_global_shape)
-        x = torch.randn(*x_local_shape).to(dtype)
+        x = torch.randn(*x_local_shape, device=device).to(dtype)
         x = pad_layer.forward(x)
     x.requires_grad = True
 
-    dy = zero_volume_tensor(x_global_shape[0])
+    dy = zero_volume_tensor(x_global_shape[0], device=device)
     if P_x.active:
-        dy = torch.randn(*x.shape).to(dtype)
+        dy = torch.randn(*x.shape, device=device).to(dtype)
 
     x_clone = x.clone()
     dy_clone = dy.clone()

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -1,8 +1,12 @@
+import os
+
 import numpy as np
 import pytest
 import torch
 
 import distdl
+
+use_cuda = 'USE_CUDA' in os.environ
 
 input_parametrizations = []
 
@@ -109,6 +113,8 @@ def test_distributed_loss(barrier_fence_fixture,
     from distdl.nn import DistributedTranspose
     from distdl.utilities.torch import zero_volume_tensor
 
+    device = torch.device('cuda' if use_cuda else 'cpu')
+
     # Isolate the minimum needed ranks
     base_comm, active = comm_split_fixture
     if not active:
@@ -122,20 +128,20 @@ def test_distributed_loss(barrier_fence_fixture,
     P_0_base = P_x_base.create_partition_inclusive([0])
     P_0 = P_0_base.create_cartesian_topology_partition([1]*len(P_x_shape))
 
-    scatter = DistributedTranspose(P_0, P_x)
-    gather = DistributedTranspose(P_x, P_0)
+    scatter = DistributedTranspose(P_0, P_x).to(device)
+    gather = DistributedTranspose(P_x, P_0).to(device)
 
     for reduction in DistributedLoss._valid_reductions:
 
-        distributed_criterion = DistributedLoss(P_x, reduction=reduction)
-        sequential_criterion = SequentialLoss(reduction=reduction)
+        distributed_criterion = DistributedLoss(P_x, reduction=reduction).to(device)
+        sequential_criterion = SequentialLoss(reduction=reduction).to(device)
 
         with torch.no_grad():
-            x_g = zero_volume_tensor()
-            y_g = zero_volume_tensor()
+            x_g = zero_volume_tensor(device=device)
+            y_g = zero_volume_tensor(device=device)
             if P_0.active:
-                x_g = torch.rand(x_global_shape)
-                y_g = torch.rand(x_global_shape)
+                x_g = torch.rand(x_global_shape, device=device)
+                y_g = torch.rand(x_global_shape, device=device)
 
             x_l = scatter(x_g)
             y_l = scatter(y_g)

--- a/tests/test_sum_reduce.py
+++ b/tests/test_sum_reduce.py
@@ -1,7 +1,11 @@
+import os
+
 import numpy as np
 import pytest
 import torch
 from adjoint_test import check_adjoint_test_tight
+
+use_cuda = 'USE_CUDA' in os.environ
 
 adjoint_parametrizations = []
 
@@ -152,6 +156,8 @@ def test_sum_reduce_adjoint(barrier_fence_fixture,
     from distdl.nn.sum_reduce import SumReduce
     from distdl.utilities.torch import zero_volume_tensor
 
+    device = torch.device('cuda' if use_cuda else 'cpu')
+
     # Isolate the minimum needed ranks
     base_comm, active = comm_split_fixture
     if not active:
@@ -171,16 +177,17 @@ def test_sum_reduce_adjoint(barrier_fence_fixture,
     x_local_shape = np.asarray(x_global_shape)
 
     layer = SumReduce(P_x, P_y, transpose_src=transpose_src, preserve_batch=False)
+    layer = layer.to(device)
 
-    x = zero_volume_tensor()
+    x = zero_volume_tensor(device=device)
     if P_x.active:
-        x = torch.randn(*x_local_shape)
+        x = torch.randn(*x_local_shape, device=device)
     x.requires_grad = True
 
-    dy = zero_volume_tensor()
+    dy = zero_volume_tensor(device=device)
     if P_y.active:
         # Adjoint Input
-        dy = torch.randn(*x_local_shape)
+        dy = torch.randn(*x_local_shape, device=device)
 
     # y = F @ x
     y = layer(x)
@@ -272,6 +279,8 @@ def test_sum_reduce_dtype(barrier_fence_fixture,
     from distdl.nn.sum_reduce import SumReduce
     from distdl.utilities.torch import zero_volume_tensor
 
+    device = torch.device('cuda' if use_cuda else 'cpu')
+
     # Isolate the minimum needed ranks
     base_comm, active = comm_split_fixture
     if not active:
@@ -291,10 +300,11 @@ def test_sum_reduce_dtype(barrier_fence_fixture,
     x_local_shape = np.asarray(x_global_shape)
 
     layer = SumReduce(P_x, P_y, transpose_src=transpose_src, preserve_batch=False)
+    layer = layer.to(device)
 
-    x = zero_volume_tensor()
+    x = zero_volume_tensor(device=device)
     if P_x.active:
-        x = 10*torch.randn(*x_local_shape).to(dtype)
+        x = 10*torch.randn(*x_local_shape, device=device).to(dtype)
 
     x.requires_grad = test_backward
 
@@ -307,10 +317,10 @@ def test_sum_reduce_dtype(barrier_fence_fixture,
         assert y.dtype == dtype
 
     if test_backward:
-        dy = zero_volume_tensor()
+        dy = zero_volume_tensor(device=device)
         if P_y.active:
             # Adjoint Input
-            dy = 10*torch.randn(*x_local_shape).to(dtype)
+            dy = 10*torch.randn(*x_local_shape, device=device).to(dtype)
 
         # dx = F* @ dy
         y.backward(dy)

--- a/tests/test_transpose.py
+++ b/tests/test_transpose.py
@@ -1,7 +1,11 @@
+import os
+
 import numpy as np
 import pytest
 import torch
 from adjoint_test import check_adjoint_test_tight
+
+use_cuda = 'USE_CUDA' in os.environ
 
 adjoint_parametrizations = []
 
@@ -142,6 +146,8 @@ def test_transpose_adjoint(barrier_fence_fixture,
     from distdl.utilities.slicing import compute_subshape
     from distdl.utilities.torch import zero_volume_tensor
 
+    device = torch.device('cuda' if use_cuda else 'cpu')
+
     # Isolate the minimum needed ranks
     base_comm, active = comm_split_fixture
     if not active:
@@ -157,9 +163,10 @@ def test_transpose_adjoint(barrier_fence_fixture,
 
     # The global tensor size is the same for x and y
     layer = DistributedTranspose(P_x, P_y, preserve_batch=False)
+    layer = layer.to(device)
 
     # Forward Input
-    x = zero_volume_tensor()
+    x = zero_volume_tensor(device=device)
     if P_x.active:
         if balanced:
             x_local_shape = compute_subshape(P_x.shape,
@@ -172,17 +179,17 @@ def test_transpose_adjoint(barrier_fence_fixture,
             x_local_shape = quotient.copy()
             x_local_shape[loc] += remainder[loc]
 
-        x = torch.randn(*x_local_shape)
+        x = torch.randn(*x_local_shape, device=device)
 
     x.requires_grad = True
 
     # Adjoint Input
-    dy = zero_volume_tensor()
+    dy = zero_volume_tensor(device=device)
     if P_y.active:
         y_local_shape = compute_subshape(P_y.shape,
                                          P_y.index,
                                          x_global_shape)
-        dy = torch.randn(*y_local_shape)
+        dy = torch.randn(*y_local_shape, device=device)
 
     # y = F @ x
     y = layer(x)
@@ -255,6 +262,8 @@ def test_excepts_mismatched_input_partition_tensor(barrier_fence_fixture,
     from distdl.utilities.slicing import compute_subshape
     from distdl.utilities.torch import zero_volume_tensor
 
+    device = torch.device('cuda' if use_cuda else 'cpu')
+
     # Isolate the minimum needed ranks
     base_comm, active = comm_split_fixture
     if not active:
@@ -278,14 +287,15 @@ def test_excepts_mismatched_input_partition_tensor(barrier_fence_fixture,
 
     with pytest.raises(ValueError) as e_info:  # noqa: F841
         layer = DistributedTranspose(P_x, P_y)
+        layer = layer.to(device)
 
         # Forward Input
-        x = zero_volume_tensor()
+        x = zero_volume_tensor(device=device)
         if P_x.active:
             x_local_shape = compute_subshape(P_x.shape,
                                              P_x.index,
                                              x_global_shape)
-            x = torch.randn(*x_local_shape)
+            x = torch.randn(*x_local_shape, device=device)
         x.requires_grad = True
 
         layer(x)
@@ -308,6 +318,8 @@ def test_excepts_mismatched_output_partition_tensor(barrier_fence_fixture,
     from distdl.nn.transpose import DistributedTranspose
     from distdl.utilities.slicing import compute_subshape
     from distdl.utilities.torch import zero_volume_tensor
+
+    device = torch.device('cuda' if use_cuda else 'cpu')
 
     # Isolate the minimum needed ranks
     base_comm, active = comm_split_fixture
@@ -332,14 +344,15 @@ def test_excepts_mismatched_output_partition_tensor(barrier_fence_fixture,
 
     with pytest.raises(ValueError) as e_info:  # noqa: F841
         layer = DistributedTranspose(P_x, P_y)
+        layer = layer.to(device)
 
         # Forward Input
-        x = zero_volume_tensor()
+        x = zero_volume_tensor(device=device)
         if P_x.active:
             x_local_shape = compute_subshape(P_x.shape,
                                              P_x.index,
                                              x_global_shape)
-            x = torch.randn(*x_local_shape)
+            x = torch.randn(*x_local_shape, device=device)
         x.requires_grad = True
 
         layer(x)
@@ -362,6 +375,8 @@ def test_excepts_mismatched_nondivisible_tensor(barrier_fence_fixture,
     from distdl.nn.transpose import DistributedTranspose
     from distdl.utilities.slicing import compute_subshape
     from distdl.utilities.torch import zero_volume_tensor
+
+    device = torch.device('cuda' if use_cuda else 'cpu')
 
     # Isolate the minimum needed ranks
     base_comm, active = comm_split_fixture
@@ -387,14 +402,15 @@ def test_excepts_mismatched_nondivisible_tensor(barrier_fence_fixture,
 
     with pytest.raises(ValueError) as e_info:  # noqa: F841
         layer = DistributedTranspose(P_x, P_y)
+        layer = layer.to(device)
 
         # Forward Input
-        x = zero_volume_tensor()
+        x = zero_volume_tensor(device=device)
         if P_x.active:
             x_local_shape = compute_subshape(P_x.shape,
                                              P_x.index,
                                              x_global_shape)
-            x = torch.randn(*x_local_shape)
+            x = torch.randn(*x_local_shape, device=device)
         x.requires_grad = True
 
         layer(x)
@@ -471,6 +487,8 @@ def test_transpose_dtype(barrier_fence_fixture,
     from distdl.utilities.slicing import compute_subshape
     from distdl.utilities.torch import zero_volume_tensor
 
+    device = torch.device('cuda' if use_cuda else 'cpu')
+
     # Isolate the minimum needed ranks
     base_comm, active = comm_split_fixture
     if not active:
@@ -486,14 +504,15 @@ def test_transpose_dtype(barrier_fence_fixture,
 
     # The global tensor size is the same for x and y
     layer = DistributedTranspose(P_x, P_y, preserve_batch=False)
+    layer = layer.to(device)
 
     # Forward Input
-    x = zero_volume_tensor(dtype=dtype)
+    x = zero_volume_tensor(dtype=dtype, device=device)
     if P_x.active:
         x_local_shape = compute_subshape(P_x.shape,
                                          P_x.index,
                                          x_global_shape)
-        x = 10*torch.randn(*x_local_shape).to(dtype)
+        x = 10*torch.randn(*x_local_shape, device=device).to(dtype)
 
     x.requires_grad = test_backward
     # y = F @ x
@@ -503,12 +522,12 @@ def test_transpose_dtype(barrier_fence_fixture,
 
     if test_backward:
         # Adjoint Input
-        dy = zero_volume_tensor(dtype=dtype)
+        dy = zero_volume_tensor(dtype=dtype, device=device)
         if P_y.active:
             y_local_shape = compute_subshape(P_y.shape,
                                              P_y.index,
                                              x_global_shape)
-            dy = 10*torch.randn(*y_local_shape).to(dtype)
+            dy = 10*torch.randn(*y_local_shape, device=device).to(dtype)
 
         # dx = F* @ dy
         y.backward(dy)
@@ -567,6 +586,8 @@ def test_transpose_identity(barrier_fence_fixture,
     from distdl.utilities.slicing import compute_subshape
     from distdl.utilities.torch import zero_volume_tensor
 
+    device = torch.device('cuda' if use_cuda else 'cpu')
+
     # Isolate the minimum needed ranks
     base_comm, active = comm_split_fixture
     if not active:
@@ -581,9 +602,10 @@ def test_transpose_identity(barrier_fence_fixture,
 
     # The global tensor size is the same for x and y
     layer = DistributedTranspose(P_x, P_y, preserve_batch=False)
+    layer = layer.to(device)
 
     # Forward Input
-    x = zero_volume_tensor()
+    x = zero_volume_tensor(device=device)
     if P_x.active:
         if balanced:
             x_local_shape = compute_subshape(P_x.shape,
@@ -596,17 +618,17 @@ def test_transpose_identity(barrier_fence_fixture,
             x_local_shape = quotient.copy()
             x_local_shape[loc] += remainder[loc]
 
-        x = torch.randn(*x_local_shape)
+        x = torch.randn(*x_local_shape, device=device)
 
     x.requires_grad = True
 
     # Adjoint Input
-    dy = zero_volume_tensor()
+    dy = zero_volume_tensor(device=device)
     if P_y.active:
         y_local_shape = compute_subshape(P_y.shape,
                                          P_y.index,
                                          x_global_shape)
-        dy = torch.randn(*y_local_shape)
+        dy = torch.randn(*y_local_shape, device=device)
 
     # y = F @ x
     y = layer(x)


### PR DESCRIPTION
This adds GPU support to the MPI backend for the following layers:
- [x] all sum reduce
- [x] batchnorm
- [x] transpose
- [ ] ~~conv channel~~
- [x] conv feature
- [ ] ~~conv general~~
- [x] halo exchange
- [ ] ~~interpolate~~*
- [x] linear
- [x] loss
- [x] padnd
- [x] pooling
- [x] sum reduce
- [x] transpose
- [ ] ~~upsampling~~*
- [x] unpadnd

\* will be done in a different PR b/c it involves working with the C++ implementation